### PR TITLE
Allow X-Original-To for address test

### DIFF
--- a/src/lib-sieve/tst-address.c
+++ b/src/lib-sieve/tst-address.c
@@ -115,7 +115,7 @@ static const char * const _allowed_headers[] = {
 	"abuse-reports-to", "x-complaints-to", "x-report-abuse-to",
 
 	/* Undocumented */
-	"x-beenthere",
+	"x-beenthere", "x-original-to",
 
 	NULL
 };


### PR DESCRIPTION
X-Original-To also contains email addresses, very useful for filtering (eg. when using the + delimiter)
