### PR TITLE
subaddress: Support multiple recipient_delimiters

### DIFF
--- a/src/lib-sieve/plugins/subaddress/ext-subaddress.c
+++ b/src/lib-sieve/plugins/subaddress/ext-subaddress.c
@@ -143,8 +143,10 @@ static const char *subaddress_user_extract_from
 	struct ext_subaddress_config *config =
 		(struct ext_subaddress_config *) addrp->object.ext->context;
 	const char *delim;
+	size_t idx;
 
-	delim = strstr(address->local_part, config->delimiter);
+	idx = strcspn(address->local_part, config->delimiter);
+	delim = address->local_part[idx] != '\0' ? address->local_part + idx : NULL;
 
 	if ( delim == NULL ) return address->local_part;
 
@@ -157,14 +159,14 @@ static const char *subaddress_detail_extract_from
 	struct ext_subaddress_config *config =
 		(struct ext_subaddress_config *) addrp->object.ext->context;
 	const char *delim;
+	size_t idx;
 
-	if ( (delim=strstr(address->local_part, config->delimiter)) == NULL )
-		return NULL;
-
-	delim += strlen(config->delimiter);
+	idx = strcspn(address->local_part, config->delimiter);
+	delim = address->local_part[idx] != '\0' ? address->local_part + idx + 1: NULL;
 
 	/* Just to be sure */
-	if ( delim > (address->local_part + strlen(address->local_part)) )
+	if ( delim == NULL ||
+			delim > (address->local_part + strlen(address->local_part)) )
 		return NULL;
 
 	return delim;

--- a/tests/extensions/subaddress/config.svtest
+++ b/tests/extensions/subaddress/config.svtest
@@ -11,8 +11,8 @@ Test!
 .
 ;
 
-test_set "envelope.to" "friep++frop@dovecot.example.net";
-test_set "envelope.from" "list--request@lists.dovecot.example.net";
+test_set "envelope.to" "friep+-frop@dovecot.example.net";
+test_set "envelope.from" "list_request@lists.dovecot.example.net";
 
 test "Delimiter default" {
 	if not address :is :user "from" "stephan" {
@@ -37,22 +37,43 @@ test "Delimiter \"-\"" {
 	}
 }
 
-test "Delimiter \"++\"" {
-	test_config_set "recipient_delimiter" "++";
+test "Delimiter \"+-\"" {
+	test_config_set "recipient_delimiter" "+-";
 	test_config_reload :extension "subaddress";
 
 	if not envelope :is :user "to" "friep" {
 		test_fail "wrong user part extracted";
 	}
 
-	if not envelope :is :detail "to" "frop" {
+	if not envelope :is :detail "to" "-frop" {
 		test_fail "wrong detail part extracted";
 	}
 }
 
-test "Delimiter \"--\"" {
-	test_config_set "recipient_delimiter" "--";
+test "Delimiter \"-+\"" {
+	test_config_set "recipient_delimiter" "-+";
 	test_config_reload :extension "subaddress";
+
+	if not envelope :is :user "to" "friep" {
+		test_fail "wrong user part extracted";
+	}
+
+	if not envelope :is :detail "to" "-frop" {
+		test_fail "wrong detail part extracted";
+	}
+}
+
+test "Delimiter \"+-_\"" {
+	test_config_set "recipient_delimiter" "+-_";
+	test_config_reload :extension "subaddress";
+
+	if not envelope :is :user "to" "friep" {
+		test_fail "wrong user part extracted";
+	}
+
+	if not envelope :is :detail "to" "-frop" {
+		test_fail "wrong detail part extracted";
+	}
 
 	if not envelope :is :user "from" "list" {
 		test_fail "wrong user part extracted";
@@ -60,18 +81,5 @@ test "Delimiter \"--\"" {
 
 	if not envelope :is :detail "from" "request" {
 		test_fail "wrong detail part extracted";
-	}
-}
-
-test "Delimiter \"+-\"" {
-	test_config_set "recipient_delimiter" "+-";
-	test_config_reload :extension "subaddress";
-
-	if envelope :is :user "from" "list" {
-		test_fail "user part extracted";
-	}
-
-	if envelope :is :detail "from" "request" {
-		test_fail "detail part extracted";
 	}
 }


### PR DESCRIPTION
The recipient_delimiter is treated as multiple one-character delimiters
rather than one multi-character delimiter if more than one character is
supplied.

Based on a patch by: Lennart Weller lhw@ring0.de

This is intended to be paired with https://github.com/dovecot/core/pull/4 in the dovecot core code (or maybe https://github.com/dovecot/core/pull/3, which I just noticed as I was posting these).
