### PR TITLE
kludge to fix managesieve choking on virtual namespaces

### DIFF
--- a/src/managesieve/main.c
+++ b/src/managesieve/main.c
@@ -241,7 +241,7 @@ int main(int argc, char *argv[])
 	};
 	struct master_login_settings login_set;
 	enum master_service_flags service_flags = 0;
-	enum mail_storage_service_flags storage_service_flags = 0;
+	enum mail_storage_service_flags storage_service_flags = MAIL_STORAGE_SERVICE_FLAG_NO_NAMESPACES;
 	const char *username = NULL;
 	int c;
 


### PR DESCRIPTION
not sure if sieve should operate on non-virtual namespaces.  however currently it tries to handle virtual namespaces and chokes in dovecot lib-storage.  this prevents it handling all namespaces (requires a fix for lib-storage to stop it deref a null pointer) and there may be a better fix.
