### PR TITLE
When binary and script have same mtime they should be seen as up-to-date

### DIFF
--- a/src/lib-sieve/storage/file/sieve-file-script.c
+++ b/src/lib-sieve/storage/file/sieve-file-script.c
@@ -494,7 +494,7 @@ static int sieve_file_script_binary_read_metadata
 
 	if ( bstat->st_mtime < sstat->st_mtime ||
 		(bstat->st_mtime == sstat->st_mtime &&
-			ST_MTIME_NSEC(*bstat) <= ST_MTIME_NSEC(*sstat)) ) {
+			ST_MTIME_NSEC(*bstat) < ST_MTIME_NSEC(*sstat)) ) {
 		if ( svinst->debug ) {
 			sieve_script_sys_debug(script,
 				"Sieve binary `%s' is not newer "

--- a/src/lib-sieve/storage/ldap/sieve-ldap-script.c
+++ b/src/lib-sieve/storage/ldap/sieve-ldap-script.c
@@ -134,7 +134,7 @@ static int sieve_ldap_script_binary_read_metadata
 	string_t *dn, *modattr;
 
 	/* config file changed? */
-	if ( bmtime <= lstorage->set_mtime ) {
+	if ( bmtime < lstorage->set_mtime ) {
 		if ( svinst->debug ) {
 			sieve_script_sys_debug(script,
 				"Sieve binary `%s' is not newer "


### PR DESCRIPTION
At the moment when the compiled sieve script has an modified time that is exactly the same as the source script it is seen as out of date and in need of a recompile.

This causes problems when compiling scripts with [Nix](https://nixos.org/nix/) because it sets the mtime for all files to 1970-01-01 01:00:01.0 and stores them in a read-only path. Meaning the scripts get recompiled at each invocation.

This pull request simply changes the logic so that when binary and source have same mtime binary is seen as up-to-date. It does this both for files and for ldap even though this is primarily a problem with files to keep the logic consistent between the two.