### PR TITLE
Make it easier to differentiate which regex failed

### DIFF
--- a/src/lib-sieve/plugins/spamvirustest/ext-spamvirustest-common.c
+++ b/src/lib-sieve/plugins/spamvirustest/ext-spamvirustest-common.c
@@ -526,7 +526,7 @@ int ext_spamvirustest_get_value
 				if ( regexec(&max_header->regexp, header_value, 2, match_values, 0)
 					!= 0 ) {
 					sieve_runtime_trace(renv, SIEVE_TRLVL_TESTS,
-						"regexp for header '%s' did not match "
+						"max_header regexp for header '%s' did not match "
 						"on value '%s'", max_header->header_name, header_value);
 					goto failed;
 				}
@@ -583,7 +583,7 @@ int ext_spamvirustest_get_value
 		if ( regexec(&status_header->regexp, header_value, 2, match_values, 0)
 			!= 0 ) {
 			sieve_runtime_trace(renv, SIEVE_TRLVL_TESTS,
-				"regexp for header '%s' did not match on value '%s'",
+				"status_header regexp for header '%s' did not match on value '%s'",
 				status_header->header_name, header_value);
 			goto failed;
 		}


### PR DESCRIPTION
It took me quite some time to figure out which regex of my spamtest
configuration failed. And that was more of an accident because I switched
to sieve_spamtest_max_value for a moment and suddenly it started
working. Having the different log messages would have pointed me to the
problem directly.