### PR TITLE
lib-sieve: plugins: enotify: Allow UTF-8 subject

### DIFF
--- a/src/lib-sieve/plugins/enotify/mailto/ntfy-mailto.c
+++ b/src/lib-sieve/plugins/enotify/mailto/ntfy-mailto.c
@@ -583,15 +583,14 @@ static int ntfy_mailto_send
 
 	/* Determine subject */
 	if ( nact->message != NULL ) {
-		/* FIXME: handle UTF-8 */
-		subject = str_sanitize(nact->message, NTFY_MAILTO_MAX_SUBJECT);
+		subject = str_sanitize_utf8(nact->message, NTFY_MAILTO_MAX_SUBJECT);
 	} else if ( subject == NULL ) {
 		const char *const *hsubject;
 
 		/* Fetch subject from original message */
 		if ( mail_get_headers_utf8
 			(msgdata->mail, "subject", &hsubject) > 0 )
-			subject = str_sanitize(t_strdup_printf("Notification: %s", hsubject[0]),
+			subject = str_sanitize_utf8(t_strdup_printf("Notification: %s", hsubject[0]),
 				NTFY_MAILTO_MAX_SUBJECT);
 		else
 			subject = "Notification: (no subject)";

--- a/src/lib-sieve/plugins/enotify/mailto/uri-mailto.c
+++ b/src/lib-sieve/plugins/enotify/mailto/uri-mailto.c
@@ -460,12 +460,14 @@ static bool uri_mailto_parse_headers
 		if ( *p != '\0' ) p++;
 
 		/* Verify field body */
-		if ( hname_type == _HNAME_BODY ) {
-			// FIXME: verify body ...
-		} else {
+		switch ( hname_type ) {
+		case _HNAME_BODY:
+		case _HNAME_SUBJECT:
+			break;
+		default:
 			if ( !rfc2822_header_field_body_verify
 				(str_c(field), str_len(field), FALSE, FALSE) ) {
-				uri_mailto_error(parser, "invalid header field body");
+				uri_mailto_error(parser, "invalid header field value");
 				return FALSE;
 			}
 		}


### PR DESCRIPTION
If the sieve enotify command is invoked with a subject (either in the
notification URL or as the "body" of the enotify command), a URI
validation routine may reject it with

    error: notify action: invalid mailto URI: invalid header field body

This is an unnecessary failure, since the enotify command would
subsequently sanitize illegal Unicode characters and MIME-encode the
Subject: header correctly anyway.

Furthermore, the error message is confusing: it's not the "body"
parameter of the URI that caused the failure, but the value of the
"subject" parameter that caused the rejection.