### PR TITLE
Silence 32-bit sign compare warning

### DIFF
--- a/src/lib-sieve/sieve-binary.c
+++ b/src/lib-sieve/sieve-binary.c
@@ -196,7 +196,7 @@ void sieve_binary_get_resource_usage(struct sieve_binary *sbin,
 	time_t update_time = header->resource_usage.update_time;
 	unsigned int timeout = sbin->svinst->resource_usage_timeout_secs;
 
-	if (update_time != 0 && (ioloop_time - update_time) > timeout)
+	if (update_time != 0 && (ioloop_time - update_time) > (time_t)timeout)
 		i_zero(&header->resource_usage);
 
 	sieve_resource_usage_init(rusage_r);


### PR DESCRIPTION
```
sieve-binary.c: In function 'sieve_binary_get_resource_usage':
sieve-binary.c:199:54: warning: comparison of integer expressions of different signedness: 'time_t' {aka 'long int'} and 'unsigned int' [-Wsign-compare]
  199 |  if (update_time != 0 && (ioloop_time - update_time) > timeout)
      |                                                      ^
```