### PR TITLE
add X-Forwarded-For, X-Forwarded-To headers when redirect

### DIFF
--- a/src/lib-sieve/cmd-redirect.c
+++ b/src/lib-sieve/cmd-redirect.c
@@ -385,7 +385,13 @@ act_redirect_send(const struct sieve_action_exec_env *aenv, struct mail *mail,
 			rfc2822_header_append(hdr, "X-Sieve-Redirected-From",
 					      smtp_address_encode(user_email),
 					      FALSE, NULL);
+			rfc2822_header_append(hdr, "X-Forwarded-For",
+					      smtp_address_encode(user_email),
+					      FALSE, NULL);
 		}
+		rfc2822_header_append(hdr, "X-Forwarded-To",
+				      smtp_address_encode(ctx->to_address),
+				      FALSE, NULL);
 
 		/* Add new Message-ID if message doesn't have one */
 		if (new_msg_id != NULL)


### PR DESCRIPTION
According to https://support.google.com/mail/answer/175365?hl=en#admins

Add forwarding headers: To let email servers know that a message is forwarded, add an X-Forwarded-For: or X-Forwarded-To: message header. Receiving servers manage forwarded messages differently than direct, incoming messages.

Does this makes sense?