### PR TITLE
lib-sieve: don't reuse save_mode for directory

### DIFF
--- a/src/lib-sieve/sieve-script.c
+++ b/src/lib-sieve/sieve-script.c
@@ -748,7 +748,7 @@ int sieve_script_binary_save_default(struct sieve_script *script ATTR_UNUSED,
 	if (storage->bin_path != NULL &&
 	    str_begins_with(path, storage->bin_path) &&
 	    sieve_storage_setup_bin_path(
-		script->storage, mkdir_get_executable_mode(save_mode)) < 0)
+		script->storage, 0700) < 0)
 		return -1;
 
 	e_debug(script->event, "Saving binary to '%s'", path);


### PR DESCRIPTION
When a sieve script is saved as read-only, calling `sieve_storage_setup_bin_path` with `mkdir_get_executable_mode(save_mode)` where - if I understand everything correctly - `save_mode` is derived from the original sieve script's permissions, will result in a read-only (technically `0555`, `mkdir_get_executable_mode` adds the executable bit) storage directory. This will cause pigeonhole to fail when saving the compiled script, as the directory has permissions `0555`:

```
dovecot[260506]: lmtp(jasper@jappie.dev)<260940><3P0ZDyQGaWhM+wMAbxW+ag>: Debug: sieve: Script 'after/84lkfddk8d88ib7zh3zh6hmy5lrvn54x-after' successfully compiled
dovecot[260506]: lmtp(jasper@jappie.dev)<260940><3P0ZDyQGaWhM+wMAbxW+ag>: Debug: sieve: storage after: file: Created directory for binaries: /run/dovecot2/sieve/jasper
dovecot[260506]: lmtp(jasper@jappie.dev)<260940><3P0ZDyQGaWhM+wMAbxW+ag>: Debug: sieve: storage after: file: script '84lkfddk8d88ib7zh3zh6hmy5lrvn54x-after': Saving binary to '/run/dovecot2/sieve/jasper/84lkfddk8d88ib7zh3zh6hmy5lrvn54x-after.svbin'
dovecot[260506]: lmtp(jasper@jappie.dev)<260940><3P0ZDyQGaWhM+wMAbxW+ag>: Error: sieve: binary /run/dovecot2/sieve/jasper/84lkfddk8d88ib7zh3zh6hmy5lrvn54x-after.svbin: save: failed to create temporary file: open(/run/dovecot2/sieve/jasper/84lkfddk8d88ib7zh3zh6hmy5lrvn54x-after.svbin.) failed: Permission denied (euid=986(dovemail) egid=985(dovemail) missing +w perm: /run/dovecot2/sieve/jasper, dir owner missing perms)
```

Explicitly using `0700` when calling `sieve_storage_setup_bin_path` fixes this.

Extra context:
- https://github.com/NixOS/nixpkgs/pull/388463#issuecomment-3066016707
- https://dovecot.org/mailman3/archives/list/dovecot@dovecot.org/thread/ESX7NHGSEJSWXE6PWJLFPP3RC4LA5I55/