### PR TITLE
lib-sieve-tool: sieve-tool - Do not override all sieve_script settings

### DIFF
--- a/src/lib-sieve-tool/sieve-tool.c
+++ b/src/lib-sieve-tool/sieve-tool.c
@@ -587,7 +587,7 @@ sieve_tool_script_parse_location(struct sieve_tool *tool, const char *location,
 		settings_instance_find(svinst->event);
 	const char *prefix = t_strdup_printf("sieve_script/%s", storage_name);
 
-	settings_override(set_instance, "sieve_script", storage_name,
+	settings_override(set_instance, "sieve_script+", storage_name,
 			  SETTINGS_OVERRIDE_TYPE_2ND_CLI_PARAM);
 	settings_override(set_instance,
 			  t_strdup_printf("%s/sieve_script_storage", prefix),


### PR DESCRIPTION
The `sieve_tool_script_parse_location` function used by the `sieve_tool_script_compile` and `sieve_tool_script_open` functions defines a new internal sieve script storage `_file` of a type `command-line`. That new internal sieve script storage replaces all the existing configured sieve script storages instead of being added in addition to them.

As a result of that replacement, it is impossible to compile `include :global` includes (because the configured global sieve script storage is replaced and there are no default one) and it is possible to compile `include :personal` includes if and only if the default personal sieve script path (`~/sieve`) is used (because the configured personal sieve script storage is replaced but the default one is auto-detected) or if the personal `sieve_script_path` is set at the global scope.

This change modifies the behavior so that the new internal sieve script storage does not replace the existing configured sieve script storages but is added in addition o them.